### PR TITLE
Add test for global let

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -867,7 +867,7 @@ mod tests {
         if let Ok(parsed_content) = res {
             // There is a problem with the parser
             // Output the result in an error (failing the test)
-            panic!("{:?}", res);
+            panic!("{:?}", parsed_content);
         } else {
             // The code fails, which is what we want
             return parse_str(r#""#);

--- a/src/main.rs
+++ b/src/main.rs
@@ -860,7 +860,7 @@ mod tests {
     }
 
     // Parse a string of code that is meant to fail
-    fn parse_str_fail(contents: impl Into<String>) -> Parser {
+    fn parse_str_fail(contents: impl Into<String>) {
         // Parse the code
         let res = Parser::parse(contents.into().as_bytes());
         // If the code parsed without error

--- a/src/main.rs
+++ b/src/main.rs
@@ -868,9 +868,6 @@ mod tests {
             // There is a problem with the parser
             // Output the result in an error (failing the test)
             panic!("{:?}", parsed_content);
-        } else {
-            // The code fails, which is what we want
-            return parse_str(r#""#);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -864,7 +864,7 @@ mod tests {
         // Parse the code
         let res = Parser::parse(contents.into().as_bytes());
         // If the code parsed without error
-        if res.is_ok() {
+        if let Ok(parsed_content) = res {
             // There is a problem with the parser
             // Output the result in an error (failing the test)
             panic!("{:?}", res);

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,7 @@ impl Display for ParsingError {
     }
 }
 
+#[derive(Debug)]
 struct Parser {
     index: usize,
     contents: Vec<u8>,
@@ -858,6 +859,21 @@ mod tests {
         Parser::parse(contents.into().as_bytes()).unwrap()
     }
 
+    // Parse a string of code that is meant to fail
+    fn parse_str_fail(contents: impl Into<String>) -> Parser {
+        // Parse the code
+        let res = Parser::parse(contents.into().as_bytes());
+        // If the code parsed without error
+        if res.is_ok() {
+            // There is a problem with the parser
+            // Output the result in an error (failing the test)
+            panic!("{:?}", res);
+        } else {
+            // The code fails, which is what we want
+            return parse_str(r#""#);
+        }
+    }
+
     #[test]
     fn test_empty() {
         parse_str(r#""#);
@@ -970,6 +986,15 @@ mod tests {
             r#"
                 const foo = "I like to say \"Hello World!\" in my code."
                 const bar = "This \\ backslash is displayed when printed!"
+            "#
+        );
+    }
+
+    #[test]
+    fn test_variable_global_let() {
+        parse_str_fail(
+            r#"
+                let foo = 0
             "#
         );
     }


### PR DESCRIPTION
I've added the test and a `parse_str_fail` function. 
I couldn't think of any other fail tests to write yet, so have only added one. 

- Added a tester for false tests, where the code is meant to fail. 
- Added a test to confirm that a global let is properly addressed.

```
running 13 tests
test tests::test_empty ... ok
test tests::test_function_call_with_args ... FAILED
test tests::test_function_call ... FAILED
test tests::test_function_with_arg ... ok
test tests::test_function_with_args ... ok
test tests::test_function_with_arg_and_result ... FAILED
test tests::test_function_with_result ... FAILED
test tests::test_function_empty ... ok
test tests::test_functions_empty ... ok
test tests::test_variable ... FAILED
test tests::test_variable_global_let ... ok
test tests::test_variable_string_with_spaces ... FAILED
test tests::test_variable_strings_with_backslashes ... FAILED
```