### PR TITLE
Implemented single line comments

### DIFF
--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -108,15 +108,12 @@ impl Parser {
     Ok(parser)
   }
   pub fn next_char(&mut self) -> Option<char> {
-    // get next
     let letter = *self.contents.get(self.index)? as char;
 
-    // define forward slash, newline & astrix
     let fs = '/' as u8;
     let nl = '\n' as u8;
     let ast = '*' as u8;
 
-    // increase index
     self.index += 1;
 
     // check for forward slash
@@ -129,9 +126,8 @@ impl Parser {
         loop {
           let next = self.contents.get(self.index)?;
           self.index += 1;
-          // check for end line
+          // check for newline (end of comment)
           if next == &nl {
-            // new line detected (end of comment)
             return self.next_char();
           }
         }

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -109,47 +109,44 @@ impl Parser {
   }
   pub fn next_char(&mut self) -> Option<char> {
     let letter = *self.contents.get(self.index)? as char;
-
-    let fs = '/' as u8;
-    let nl = '\n' as u8;
-    let ast = '*' as u8;
-
     self.index += 1;
 
-    // check for forward slash
-    if letter == &fs {
-      // check for next forward slash
-      let next = self.contents.get(self.index)?;
-      if next == &fs {
+    // check for the start of a comment
+    if letter != '/' {
+      return Some(letter);
+    }
+
+    // check for next forward slash
+    match *self.contents.get(self.index)? as char {
+      '/' => {
         // detected single line comment
-        // loop until newline (comments are not parsed)
         loop {
-          let next = self.contents.get(self.index)?;
+          let next = *self.contents.get(self.index)? as char;
           self.index += 1;
           // check for newline (end of comment)
-          if next == &nl {
+          if next == '\n' {
             return self.next_char();
           }
         }
-      } else if letter == &ast {
+      }
+      '*' => {
         // detected multi-line comment
-        // loop until closed (comments are not parsed)
         loop {
-          let next = self.contents.get(self.index)?;
+          let next = *self.contents.get(self.index)? as char;
           self.index += 1;
-          if next == &ast {
+          if next == '*' {
             // * detected
-            let last = self.contents.get(self.index)?;
-            if last == &ast {
+            let last = *self.contents.get(self.index)? as char;
+            if last == '/' {
               // */ detected
               self.index += 1;
-              break
+              return self.next_char();
             }
           }
         }
       }
+      _ => return Some(letter),
     }
-    Some(*letter as char)
   }
   fn seek_next_char(&mut self) -> Option<char> {
     let letter = self.contents.get(self.index)?;

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -108,8 +108,36 @@ impl Parser {
     Ok(parser)
   }
   pub fn next_char(&mut self) -> Option<char> {
+    // get next
     let letter = self.contents.get(self.index)?;
+
+    // define forward slash & newline
+    let fs: u8 = '/' as u8;
+    let nl: u8 = '\n' as u8;
+
+    // increase index
     self.index += 1;
+
+    // check for forward slash
+    if letter == &fs {
+      // check for next forward slash
+      let next = self.contents.get(self.index)?;
+      if next == &fs {
+        // detected is single line comment
+        // loop until over (comments are not parsed)
+        loop {
+          let next = self.contents.get(self.index)?;
+          self.index += 1;
+          // check for end line
+          if next == &nl {
+            // new line detected (end of comment)
+            break
+          }
+        }
+      } else /*if*/ {
+        // TODO: add multi-line comment support
+      }
+    }
     Some(*letter as char)
   }
   fn seek_next_char(&mut self) -> Option<char> {

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -111,9 +111,10 @@ impl Parser {
     // get next
     let letter = self.contents.get(self.index)?;
 
-    // define forward slash & newline
+    // define forward slash, newline & astrix
     let fs: u8 = '/' as u8;
     let nl: u8 = '\n' as u8;
+    let ast: u8 = '*' as u8;
 
     // increase index
     self.index += 1;
@@ -123,8 +124,8 @@ impl Parser {
       // check for next forward slash
       let next = self.contents.get(self.index)?;
       if next == &fs {
-        // detected is single line comment
-        // loop until over (comments are not parsed)
+        // detected single line comment
+        // loop until newline (comments are not parsed)
         loop {
           let next = self.contents.get(self.index)?;
           self.index += 1;
@@ -134,8 +135,22 @@ impl Parser {
             break
           }
         }
-      } else /*if*/ {
-        // TODO: add multi-line comment support
+      } else if letter == &ast {
+        // detected multi-line comment
+        // loop until closed (comments are not parsed)
+        loop {
+          let next = self.contents.get(self.index)?;
+          self.index += 1;
+          if next == &ast {
+            // * detected
+            let last = self.contents.get(self.index)?;
+            if last == &ast {
+              // */ detected
+              self.index += 1;
+              break
+            }
+          }
+        }
       }
     }
     Some(*letter as char)

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -132,7 +132,7 @@ impl Parser {
           // check for end line
           if next == &nl {
             // new line detected (end of comment)
-            break
+            return self.next_char();
           }
         }
       } else if letter == &ast {

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -112,9 +112,9 @@ impl Parser {
     let letter = self.contents.get(self.index)?;
 
     // define forward slash, newline & astrix
-    let fs: u8 = '/' as u8;
-    let nl: u8 = '\n' as u8;
-    let ast: u8 = '*' as u8;
+    let fs = '/' as u8;
+    let nl = '\n' as u8;
+    let ast = '*' as u8;
 
     // increase index
     self.index += 1;

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -109,7 +109,7 @@ impl Parser {
   }
   pub fn next_char(&mut self) -> Option<char> {
     // get next
-    let letter = self.contents.get(self.index)?;
+    let letter = *self.contents.get(self.index)? as char;
 
     // define forward slash, newline & astrix
     let fs = '/' as u8;

--- a/src/lib/tests/comments.rs
+++ b/src/lib/tests/comments.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn test_comment_single_line() {
-  let res = parse_str(
+  parse_str(
     r#"
       // hello world
     "#

--- a/src/lib/tests/comments.rs
+++ b/src/lib/tests/comments.rs
@@ -5,7 +5,7 @@ fn test_comment_single_line() {
   parse_str(
     r#"
       // hello world
-    "#
+    "#,
   );
 }
 
@@ -17,6 +17,34 @@ fn test_comment_multi_line() {
         Multi-line comment.
         Can contain / and * and even /*
       */
-    "#
+    "#,
+  );
+}
+
+#[test]
+fn test_comments_in_combination_with_functions() {
+  parse_str(
+    r#"
+      fn foo() {}
+      /*
+        Multi-line comment.
+        Can contain / and * and even /*
+      */
+      fn bar() {}
+    "#,
+  );
+}
+
+#[test]
+fn test_comments_inside_of_function() {
+  parse_str(
+    r#"
+      fn foo() {
+        /*
+          Multi-line comment.
+          Can contain / and * and even /*
+        */
+      }
+    "#,
   );
 }

--- a/src/lib/tests/comments.rs
+++ b/src/lib/tests/comments.rs
@@ -1,0 +1,10 @@
+use super::*;
+
+#[test]
+fn test_comment_single_line() {
+  let res = parse_str(
+    r#"
+      // hello world
+    "#
+  );
+}

--- a/src/lib/tests/comments.rs
+++ b/src/lib/tests/comments.rs
@@ -8,3 +8,15 @@ fn test_comment_single_line() {
     "#
   );
 }
+
+#[test]
+fn test_comment_multi_line() {
+  parse_str(
+    r#"
+      /*
+        Multi-line comment.
+        Can contain / and * and even /*
+      */
+    "#
+  );
+}

--- a/src/lib/tests/mod.rs
+++ b/src/lib/tests/mod.rs
@@ -1,3 +1,4 @@
+mod comments;
 mod functions;
 mod general;
 mod variables;


### PR DESCRIPTION
I've implemented single line comments into our parser. 
I decided just to ignore them, as there is no point parsing them through.

```
running 15 tests
test lib::tests::comments::test_comment_single_line ... ok
test lib::tests::functions::test_function_empty ... ok
test lib::tests::functions::test_function_with_arg ... ok
test lib::tests::functions::test_function_with_args ... ok
test lib::tests::functions::test_function_call_without_args ... ok
test lib::tests::functions::test_function_with_arg_and_result ... ok
test lib::tests::functions::test_function_with_result ... FAILED
test lib::tests::functions::test_function_call_with_args ... FAILED
test lib::tests::functions::test_functions_empty ... ok
test lib::tests::general::test_empty ... ok
test lib::tests::variables::test_variable ... FAILED
test lib::tests::variables::test_variable_global_let ... ok
test lib::tests::variables::test_variable_starts_with_number ... ok
test lib::tests::variables::test_variable_string_with_spaces ... FAILED
test lib::tests::variables::test_variable_strings_with_backslashes ... FAILED
```

Edit: Added multi-line support now