### PR TITLE
Fixed missing first char bug for function call args

### DIFF
--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -292,7 +292,7 @@ impl<'a> ParseAction<'a> {
         _ => {}
       }
 
-      let action = ParseAction::start(self.p, false, ActionToExpect::Assignment(",)"))?;
+      let action = ParseAction::start(self.p, true, ActionToExpect::Assignment(",)"))?;
       res.arguments.push(action);
       match self.p.next_while(" \t\n") {
         Some(',') => continue,

--- a/src/lib/tests/functions.rs
+++ b/src/lib/tests/functions.rs
@@ -13,9 +13,9 @@ fn test_function_empty() {
 fn test_functions_empty() {
   parse_str(
     r#"
-                fn test1() {}
-                fn test2() {}
-            "#,
+      fn test1() {}
+      fn test2() {}
+    "#,
   );
 }
 
@@ -23,8 +23,8 @@ fn test_functions_empty() {
 fn test_function_with_arg() {
   parse_str(
     r#"
-                fn test(name string) {}
-            "#,
+      fn test(name string) {}
+    "#,
   );
 }
 
@@ -32,8 +32,8 @@ fn test_function_with_arg() {
 fn test_function_with_args() {
   parse_str(
     r#"
-                fn test(foo string, bar string, baz string) {}
-            "#,
+      fn test(foo string, bar string, baz string) {}
+    "#,
   );
 }
 
@@ -52,10 +52,10 @@ fn test_function_with_result() {
 fn test_function_with_arg_and_result() {
   parse_str(
     r#"
-                fn test(ab string) string {
-                    return ab
-                }
-            "#,
+      fn test(ab string) string {
+        return ab
+      }
+    "#,
   );
 }
 
@@ -76,10 +76,12 @@ fn test_function_call_without_args() {
 fn test_function_call_with_args() {
   parse_str(
     r#"
-                fn test(a int, b int) {}
-                fn test_1() {
-                    test(1, 2)
-                }
-            "#,
+      const a = 1
+      const b = 2
+      fn test(a int, b int) {}
+      fn test_1() {
+        test(a, b)
+      }
+    "#,
   );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,9 @@ fn main() {
     file.read_to_end(&mut contents).unwrap();
     match Parser::parse(contents) {
         Err(err) => println!("{}", err),
-        Ok(res) => println!("{:?}", res.functions),
+        Ok(res) => {
+            println!("Functions: {:?}", res.functions);
+            println!("Globals: {:?}", res.global_vars);
+        },
     }
 }


### PR DESCRIPTION
Quick fix on your last commit.
You need to go back one index when calling `ParseAction::start` by passing true instead of false. 
I've also updated `test_function_call_with_args`, as currently we cannot parse numbers as arguments.
Also, since we are now using global variables more often when implementing new things, I've changed our print statement to include this for debugging. 